### PR TITLE
Adjusted from v3 to v2 for interacting with 'ike

### DIFF
--- a/daily-data-aggregator/Dockerfile
+++ b/daily-data-aggregator/Dockerfile
@@ -11,7 +11,7 @@ COPY uploader.py /usr/src/app/uploader.py
 # Install Git, to grab the scripts, and Python, to execute them.
 # Tapipy may be needed for using the uploader script, once it is written.
 RUN apt install git python3 python3-pip -y
-RUN pip3 install tapipy
+RUN pip3 install agavepy
 
 # Get latest versions of data processing scripts
 # Future: These scripts will come from the 'rainfallscripts' repo, once it's ready.


### PR DESCRIPTION
For file uploading, I believe the container needs agavepy (v2) rather than tapipy (v3) that I had put in the dockerfile earlier - since the file uploading interacts with the v2 'Ike Wai gateway.